### PR TITLE
Feature/enhanced file conversion

### DIFF
--- a/R/convert_png_to_jpg.R
+++ b/R/convert_png_to_jpg.R
@@ -1,8 +1,8 @@
-#' Convert and Process PNG Images to JPG or BMP Format
+#' Convert and Process Images Between JPG, PNG, and BMP Formats
 #'
-#' Imports PNG images, resizes them with proportional scaling, adds padding,
-#' and converts to JPG or BMP format with comprehensive error handling and
-#' batch processing capabilities.
+#' Imports JPG, PNG, or BMP images, resizes them with proportional scaling,
+#' adds padding, and converts to any of the supported output formats (JPG, PNG,
+#' or BMP) with comprehensive error handling and batch processing capabilities.
 #'
 #' @param input_path Character string specifying the path to input PNG, BMP, or JPG file(s).
 #'   Can be a single file path or directory path for batch processing.
@@ -14,10 +14,11 @@
 #'     \item{height}{Fixed height in pixels (width will be proportional)}
 #'   }
 #' @param padding Numeric value specifying padding in pixels around the image. Default: 10.
-#' @param format Character string specifying output format ("jpg", "bmp", or "png"). Default: "jpg".
-#' @param quality Numeric value (0-100) specifying JPG quality. Default: 95.
+#' @param format Character string specifying output format (\code{"jpg"}, \code{"png"}, or
+#'   \code{"bmp"}). Any input format can be converted to any output format. Default: \code{"jpg"}.
+#' @param quality Numeric value (0-100) specifying JPG quality (ignored for PNG and BMP). Default: 95.
 #' @param background Character string specifying background color for padding. Default: "white".
-#' @param batch_processing Logical indicating whether to process all PNG files in a directory.
+#' @param batch_processing Logical indicating whether to process all image files in a directory.
 #'   Only used when input_path is a directory. Default: TRUE.
 #' @param overwrite Logical indicating whether to overwrite existing files. Default: FALSE.
 #' @param verbose Logical indicating whether to print progress messages. Default: TRUE.
@@ -34,21 +35,29 @@
 #'
 #' @examples
 #' \dontrun{
-#' # Single file conversion
+#' # Convert a single PNG to JPG
 #' result <- convert_png_to_image(
 #'   input_path = "my_image.png",
 #'   dimensions = list(width = 800),
 #'   format = "jpg"
 #' )
 #'
-#' # Batch processing with custom settings
+#' # Convert a BMP to PNG with custom settings
 #' result <- convert_png_to_image(
-#'   input_path = "image_directory/",
+#'   input_path = "scan.bmp",
 #'   output_dir = "processed_images/",
 #'   dimensions = list(height = 600),
 #'   padding = 20,
-#'   format = "bmp",
-#'   background = "black"
+#'   format = "png",
+#'   background = "white"
+#' )
+#'
+#' # Batch convert a folder of mixed JPG/PNG/BMP files to BMP
+#' result <- convert_png_to_image(
+#'   input_path = "image_directory/",
+#'   output_dir = "processed_images/",
+#'   dimensions = list(width = 1200),
+#'   format = "bmp"
 #' )
 #'
 #' # High quality JPG conversion

--- a/R/image_processing.R
+++ b/R/image_processing.R
@@ -1,7 +1,9 @@
-#' Image Processing Module (PNG -> JPG/BMP)
+#' Image Processing Module (JPG / PNG / BMP Conversion)
 #'
-#' UI and server logic to convert PNG images to JPG/BMP using
-#' `convert_png_to_image()` with user-configurable options.
+#' UI and server logic to convert images between JPG, PNG, and BMP formats
+#' using `convert_png_to_image()` with user-configurable resize, padding, and
+#' quality options. All three formats are accepted as input and can be written
+#' as any of the three output formats.
 #'
 #' @param id Module id
 #' @return Invisibly returns a reactive containing the last results table
@@ -17,7 +19,7 @@ image_processing_ui <- function(id) {
       column(
         width = 12,
         box(
-          title = "Image Processing: PNG/BMP Conversion",
+          title = "Image Conversion (JPG / PNG / BMP)",
           status = "primary",
           solidHeader = TRUE,
           width = 12,
@@ -25,7 +27,7 @@ image_processing_ui <- function(id) {
           uiOutput(ns("folder_chooser_ui")),
 
           uiOutput(ns("output_dir_ui")),
-          selectInput(ns("format"), "Output format", choices = c("jpg", "bmp", "png"), selected = "jpg"),
+          selectInput(ns("format"), "Output format", choices = c("JPG" = "jpg", "PNG" = "png", "BMP" = "bmp"), selected = "jpg"),
           radioButtons(
             ns("dim_mode"), "Resize by",
             choices = c("Width" = "width", "Height" = "height"),
@@ -40,7 +42,7 @@ image_processing_ui <- function(id) {
             numericInput(ns("height"), "Target height (px)", value = 600, min = 1, step = 10)
           ),
           sliderInput(ns("padding"), "Padding (px)", min = 0, max = 100, value = 10, step = 1),
-          sliderInput(ns("quality"), "JPEG quality", min = 10, max = 100, value = 95, step = 1),
+          sliderInput(ns("quality"), "JPEG quality (ignored for PNG/BMP)", min = 10, max = 100, value = 95, step = 1),
           textInput(ns("background"), "Background color for padding", value = "white"),
           checkboxInput(ns("overwrite"), "Overwrite existing outputs", value = FALSE),
 


### PR DESCRIPTION
This pull request expands the image conversion functionality to support JPG, PNG, and BMP formats for both input and output, rather than being limited to PNG input and JPG/BMP output. It updates both the core conversion logic and the Shiny module UI/server to reflect these enhancements, and improves error handling and user guidance throughout.

**Core functionality updates:**
- Expanded accepted input formats to include JPG, PNG, and BMP, and allowed conversion between any of these formats as both input and output in `convert_png_to_image`. Updated parameter validation, error messages, and batch processing logic accordingly. [[1]](diffhunk://#diff-5df6a7b369034fe9330151e5bc2b0ee7ba919329016de2e1709dd3e17e91549fL1-R7) [[2]](diffhunk://#diff-5df6a7b369034fe9330151e5bc2b0ee7ba919329016de2e1709dd3e17e91549fL17-R21) [[3]](diffhunk://#diff-5df6a7b369034fe9330151e5bc2b0ee7ba919329016de2e1709dd3e17e91549fL163-R172) [[4]](diffhunk://#diff-5df6a7b369034fe9330151e5bc2b0ee7ba919329016de2e1709dd3e17e91549fL217-R244) [[5]](diffhunk://#diff-5df6a7b369034fe9330151e5bc2b0ee7ba919329016de2e1709dd3e17e91549fR431-R432)

**User interface and documentation improvements:**
- Updated the Shiny module UI (`image_processing_ui`) to reflect support for all three formats, including dropdown choices and UI titles. Clarified that JPEG quality is ignored for PNG/BMP outputs. [[1]](diffhunk://#diff-88047aa756e2e2ac1de17563ae37cf3be25b8b8cdea7c672ad4b9315b02a5bc7L1-R6) [[2]](diffhunk://#diff-88047aa756e2e2ac1de17563ae37cf3be25b8b8cdea7c672ad4b9315b02a5bc7L20-R30) [[3]](diffhunk://#diff-88047aa756e2e2ac1de17563ae37cf3be25b8b8cdea7c672ad4b9315b02a5bc7L43-R45)
- Revised example usage and documentation to show conversion between all supported formats and batch processing of mixed-format folders.

**Batch processing enhancements:**
- Batch processing now finds and processes all JPG, PNG, and BMP files in a directory, with updated user notifications and error messages in both the backend and UI. [[1]](diffhunk://#diff-5df6a7b369034fe9330151e5bc2b0ee7ba919329016de2e1709dd3e17e91549fL217-R244) [[2]](diffhunk://#diff-88047aa756e2e2ac1de17563ae37cf3be25b8b8cdea7c672ad4b9315b02a5bc7L231-R235)