### PR TITLE
Ref/increased plot margin

### DIFF
--- a/R/plotting_module.R
+++ b/R/plotting_module.R
@@ -204,6 +204,7 @@ plotting_ui <- function(id) {
           numericInput(ns("y_size"), "Y label size", value = 5, min = 1, step = 0.5),
           checkboxInput(ns("rotate_y"), "Rotate Y label", value = FALSE),
           checkboxInput(ns("show_borders"), "Show borders", value = TRUE),
+          numericInput(ns("plot_margin_top"), "Plot top padding (lines)", value = 1.5, min = 0, step = 0.5),
           numericInput(ns("preview_height"), "Preview height (px)", value = 600, min = 200, step = 50)
         ),
         box(
@@ -952,6 +953,7 @@ plotting_server <- function(id, data_reactive) {
         show_legend = isTRUE(input$show_legend),
         legend_offset_h = input$legend_offset_h %||% 0,
         legend_offset_v = input$legend_offset_v %||% 0.5,
+        plot_margin_top = input$plot_margin_top %||% 1.5,
         axis = list(
           linewidth = input$axis_linewidth,
           tick_length = input$tick_length,

--- a/R/shape_plot.R
+++ b/R/shape_plot.R
@@ -444,6 +444,7 @@ shape_plot <- function(data,
     show_legend = TRUE,
     legend_offset_h = 0,
     legend_offset_v = 0.5,
+    plot_margin_top = 1.5,
     axis = list(
       linewidth = 1,
       tick_length = 0.005,
@@ -1148,7 +1149,11 @@ shape_plot <- function(data,
       legend.key = ggplot2::element_rect(fill = style_colors$plot_background, color = NA),
       legend.background = ggplot2::element_rect(fill = style_colors$background, color = NA),
       legend.box.spacing = ggplot2::unit(params$styling$legend_offset_h, "lines"),
-      legend.justification = c(0, params$styling$legend_offset_v)
+      legend.justification = c(0, params$styling$legend_offset_v),
+      plot.margin = ggplot2::margin(
+        t = params$styling$plot_margin_top,
+        r = 0.5, b = 0.5, l = 0.5, unit = "lines"
+      )
     )
   
   return(plot)
@@ -1194,7 +1199,10 @@ shape_plot <- function(data,
       axis.text = ggplot2::element_blank(),
       axis.title.x = ggplot2::element_blank(),
       axis.title.y = ggplot2::element_blank(),
-      plot.margin = ggplot2::margin(tick_margin, tick_margin, tick_margin, tick_margin, unit = "lines"),
+      plot.margin = ggplot2::margin(
+        t = params$styling$plot_margin_top,
+        r = tick_margin, b = tick_margin, l = tick_margin, unit = "lines"
+      ),
       legend.position = if (isTRUE(params$styling$show_legend)) "right" else "none",
       legend.text = ggplot2::element_text(size = params$styling$text$legend_size, color = text_col),
       legend.title = ggplot2::element_text(size = params$styling$text$legend_size, color = text_col),


### PR DESCRIPTION
This pull request enhances the plotting module by adding new user-configurable options for plot appearance and improving the flexibility of the plot preview. The most important changes are grouped below.

**User Interface Enhancements:**

* Added numeric inputs in `plotting_ui` for users to control the plot's top margin (`plot_margin_top`) and preview height (`preview_height`).
* Updated the UI to render the plot output with a dynamic height based on the new `preview_height` input, replacing the static plot output. [[1]](diffhunk://#diff-342b79e183ae7755ddb81aec5d3e31dfaeb1fb6713cec75b39c6af7c1c2edcfdL297-R299) [[2]](diffhunk://#diff-342b79e183ae7755ddb81aec5d3e31dfaeb1fb6713cec75b39c6af7c1c2edcfdR1223-R1227)

**Plot Styling and Customization:**

* Passed the new `plot_margin_top` parameter from the UI to the plot rendering logic, allowing users to adjust the top padding of plots. [[1]](diffhunk://#diff-342b79e183ae7755ddb81aec5d3e31dfaeb1fb6713cec75b39c6af7c1c2edcfdR956) [[2]](diffhunk://#diff-1157533819873ad449849c6c3b8555d9cabb124b7a1a8559809e8df328573e5eR447)
* Modified the plot theme in `shape_plot` to use the user-specified `plot_margin_top` for the top plot margin, both for standard and blank axis themes. [[1]](diffhunk://#diff-1157533819873ad449849c6c3b8555d9cabb124b7a1a8559809e8df328573e5eL1151-R1156) [[2]](diffhunk://#diff-1157533819873ad449849c6c3b8555d9cabb124b7a1a8559809e8df328573e5eL1197-R1205)