### PR TITLE
Changed overlay valeus for PC contrib plot, because +/- 2sd can show …

### DIFF
--- a/R/pc_contribution_plots_module.R
+++ b/R/pc_contribution_plots_module.R
@@ -468,8 +468,11 @@ pc_contribution_plots_server <- function(id) {
     }
 
     # --- Overlay cell: -2SD (blue) vs +2SD (red) ---
-    coords_neg2 <- pc_shapes[["sd-2"]]
-    coords_pos2 <- pc_shapes[["sd2"]]
+    coords_neg2 <- pc_shapes[["sd-1"]]
+    coords_pos2 <- pc_shapes[["sd1"]]
+    # Note: using -1 SD shape for better visibility of
+    # differences, as -2 SD can be very extreme
+    #test
 
     graphics::par(mar = c(0.5, 0.5, 1.8, 0.5), bg = "white")
 

--- a/R/pc_contribution_plots_module.R
+++ b/R/pc_contribution_plots_module.R
@@ -472,7 +472,7 @@ pc_contribution_plots_server <- function(id) {
     coords_pos2 <- pc_shapes[["sd1"]]
     # Note: using -1 SD shape for better visibility of
     # differences, as -2 SD can be very extreme
-    #test
+
 
     graphics::par(mar = c(0.5, 0.5, 1.8, 0.5), bg = "white")
 


### PR DESCRIPTION
Changed overlay valeus for PC contrib plot, because +/- 2sd can show extreme values/shapes that are not present in the data